### PR TITLE
Fix typos in parser source

### DIFF
--- a/pos.go
+++ b/pos.go
@@ -151,7 +151,7 @@ func (this *pos) ConsumeRE(re *regexp.Regexp, negative bool) (string, *Error) {
 		return "", this.NewErrorf("expected /%v/ got %q", re, this.Rem(80))
 	}
 	if m[0] != 0 {
-		panic("re must match from the beginnin")
+		panic("re must match from the beginning")
 	}
 	out := this.src.bytes[this.at : this.at+m[1]]
 	if negative {
@@ -179,7 +179,7 @@ func (this *pos) consumeProds(prods ...*Prod) (any, *Error) {
 	this.stats.Alternations++
 	switch len(prods) {
 	case 0:
-		panic("no alternatives") // Verify() woudl have catched this
+		panic("no alternatives") // Verify() would have caught this
 	case 1:
 		prod := prods[0]
 		p := *this

--- a/src.go
+++ b/src.go
@@ -13,11 +13,11 @@ func (this *Src) Line(offset int) int {
 	}
 	if this.linesLength == nil {
 		lines := bytes.Split(this.bytes, []byte{'\n'})
-		lenghts := make([]int, len(lines))
+		lengths := make([]int, len(lines))
 		for i, l := range lines {
-			lenghts[i] = len(l)
+			lengths[i] = len(l)
 		}
-		this.linesLength = lenghts
+		this.linesLength = lengths
 	}
 	for i, l := range this.linesLength {
 		offset -= l


### PR DESCRIPTION
## Summary
- fix panic message typo in `ConsumeRE`
- fix comment in `consumeProds`
- fix variable name in `Src.Line`

## Testing
- `go test ./...` *(fails: module download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685ef59f17888321a9882ccd54ac752b