### PR TITLE
Fix line numbering in Src

### DIFF
--- a/src.go
+++ b/src.go
@@ -17,13 +17,18 @@ func (this *Src) Line(offset int) int {
 		for i, l := range lines {
 			lengths[i] = len(l)
 		}
+		for i := 0; i < len(lengths)-1; i++ {
+			lengths[i]++ // account for '\n'
+		}
 		this.linesLength = lengths
 	}
-	for i, l := range this.linesLength {
-		offset -= l
-		if offset < 0 {
-			return i
+	line := 1
+	for _, l := range this.linesLength {
+		if offset < l {
+			return line
 		}
+		offset -= l
+		line++
 	}
-	return len(this.linesLength) // out of bounds
+	return line // out of bounds
 }

--- a/src.go
+++ b/src.go
@@ -30,5 +30,5 @@ func (this *Src) Line(offset int) int {
 		offset -= l
 		line++
 	}
-	return line // out of bounds
+	return len(this.linesLength) // clamp to last line
 }

--- a/src_test.go
+++ b/src_test.go
@@ -1,0 +1,43 @@
+package parse
+
+import "testing"
+
+func TestSrcLine(t *testing.T) {
+	src := Src{bytes: []byte("a\nb\nc")}
+	tests := []struct {
+		off  int
+		line int
+	}{
+		{0, 1},
+		{1, 1},
+		{2, 2},
+		{3, 2},
+		{4, 3},
+		{5, 3},
+	}
+	for _, tt := range tests {
+		got := src.Line(tt.off)
+		if got != tt.line {
+			t.Errorf("offset %d: expected line %d got %d", tt.off, tt.line, got)
+		}
+	}
+}
+
+func TestSrcLineTrailingNewline(t *testing.T) {
+	src := Src{bytes: []byte("a\nb\n")}
+	tests := []struct {
+		off  int
+		line int
+	}{
+		{0, 1},
+		{1, 1},
+		{2, 2},
+		{3, 2},
+		{4, 3},
+	}
+	for _, tt := range tests {
+		if got := src.Line(tt.off); got != tt.line {
+			t.Errorf("offset %d: expected line %d got %d", tt.off, tt.line, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- compute line numbers based on newline characters
- change `Src.Line` to be 1-based
- add unit tests for multi-line inputs

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685ef69ab2ac8321bed1fc298194c194